### PR TITLE
Warn user if flash plant is used with impedance model

### DIFF
--- a/src/geophires_x/SurfacePlant.py
+++ b/src/geophires_x/SurfacePlant.py
@@ -670,6 +670,12 @@ class SurfacePlant:
                             if ParameterToModify.value in [PlantType.SINGLE_FLASH, PlantType.DOUBLE_FLASH]:
                                 model.wellbores.impedancemodelallowed.value = False
                                 self.setinjectionpressurefixed = True
+                        if model.wellbores.impedancemodelused.value and \
+                            ParameterToModify.value in [PlantType.SINGLE_FLASH, PlantType.DOUBLE_FLASH]:
+                            msg = ('Flash plant is being used with impedance model. When reservoir impedance '
+                                   'is specified, no flashing is allowed in production wells or at surface.')
+                            print(f'Warning: {msg}')
+                            model.logger.warning(msg)
                     elif ParameterToModify.Name == 'Plant Outlet Pressure':
                         if ParameterToModify.value < self.plant_outlet_pressure.Min or ParameterToModify.value > self.plant_outlet_pressure.Max:
                                 if self.setinjectionpressurefixed:


### PR DESCRIPTION
# Description

This is to resolve #337.

# Testing & Verification

1. Unit test added: [SurfacePlantTestCase.test_flash_plant_with_impedance_model_warning](https://github.com/NREL/GEOPHIRES-X/compare/main...jeffbourdier:GEOPHIRES-X:main?expand=1#diff-5bc5da06375198c1bdfc7002928167bc13527c20313810f78902aa9733f42882)
1. Manual testing: [generic-egs-case](https://github.com/NREL/GEOPHIRES-X/blob/main/tests/geophires_x_tests/generic-egs-case.txt)
