### PR TITLE
Clamp negative electricity production to zero

### DIFF
--- a/src/geophires_x/SurfacePlant.py
+++ b/src/geophires_x/SurfacePlant.py
@@ -153,15 +153,17 @@ class SurfacePlant:
         # calculate electricity/heat - first, calculate the total amount of heat extracted from geofluid [MWth] (same for all)
         HeatExtracted = nprod * prodwellflowrate * cpwater * (ProducedTemperature - Tinj) / 1E6
 
+        def _clamp_electricity(electricity: np.ndarray) -> np.ndarray:
+            if np.any(electricity < 0):
+                # TODO: make message more informative (possibly by hinting that maximum temperature may be too high)
+                if hasattr(self, "logger"):
+                    self.logger.warning("Electricity production calculated as negative. Clamping to zero.")
+                electricity = np.maximum(electricity, 0)
+
+            return electricity
+
         # next do the electricity produced - the same for all, except enduse=5, where it is recalculated
-        ElectricityProduced = availability * etau * nprod * prodwellflowrate
-        if ElectricityProduced.max() < 0:
-            # TODO: make message more informative (possibly by hinting that maximum temperature may be too high)
-            if enduse_option == EndUseOptions.HEAT:
-                # Electricity is not produced for direct-use heat applications, so clamp negative values to zero
-                ElectricityProduced = np.zeros_like(ElectricityProduced)
-            else:
-                raise RuntimeError('Electricity production calculated as negative.')
+        ElectricityProduced = _clamp_electricity(availability * etau * nprod * prodwellflowrate)
 
         if enduse_option == EndUseOptions.ELECTRICITY:
             # pure electricity
@@ -182,10 +184,12 @@ class SurfacePlant:
         elif enduse_option in [EndUseOptions.COGENERATION_PARALLEL_EXTRA_ELECTRICITY, EndUseOptions.COGENERATION_PARALLEL_EXTRA_HEAT]:
             # enduse_option = 5: cogen split of mass flow rate
             # electricity part [MWe]
-            ElectricityProduced = availability * etau * nprod * prodwellflowrate * (1. - chp_fraction)
+            ElectricityProduced = _clamp_electricity(
+                availability * etau * nprod * prodwellflowrate * (1.0 - chp_fraction)
+            )
             # useful heat part for direct-use application [MWth]
             HeatProduced = enduse_efficiency_factor * chp_fraction * nprod * prodwellflowrate * cpwater * (ProducedTemperature - Tinj) / 1E6
-            HeatExtractedTowardsElectricity = (1. - chp_fraction) * nprod * prodwellflowrate * cpwater * (ProducedTemperature - Tinj) / 1E6
+            HeatExtractedTowardsElectricity = (1.0 - chp_fraction) * nprod * prodwellflowrate * cpwater * (ProducedTemperature - Tinj) / 1E6
 
         return ElectricityProduced, HeatExtracted, HeatProduced, HeatExtractedTowardsElectricity
 

--- a/src/geophires_x/SurfacePlant.py
+++ b/src/geophires_x/SurfacePlant.py
@@ -157,7 +157,11 @@ class SurfacePlant:
         ElectricityProduced = availability * etau * nprod * prodwellflowrate
         if ElectricityProduced.max() < 0:
             # TODO: make message more informative (possibly by hinting that maximum temperature may be too high)
-            raise RuntimeError('Electricity production calculated as negative.')
+            if enduse_option == EndUseOptions.HEAT:
+                # Electricity is not produced for direct-use heat applications, so clamp negative values to zero
+                ElectricityProduced = np.zeros_like(ElectricityProduced)
+            else:
+                raise RuntimeError('Electricity production calculated as negative.')
 
         if enduse_option == EndUseOptions.ELECTRICITY:
             # pure electricity

--- a/tests/test_geophires_x.py
+++ b/tests/test_geophires_x.py
@@ -965,19 +965,24 @@ Print Output to Console, 1"""
             client.get_geophires_result(params)
         self.assertIn('failed to validate CLGS input value', str(e.exception))
 
-    def test_negative_electricity_production_raises_error(self):
+    def test_negative_electricity_production_clamped(self):
         client = GeophiresXClient()
-        with self.assertRaises(RuntimeError) as e:
-            params = GeophiresInputParameters(
-                {
-                    'Reservoir Depth': 5,
-                    'Gradient 1': 112,
-                    'Power Plant Type': 2,
-                    'Maximum Temperature': 600,
-                }
-            )
-            client.get_geophires_result(params)
-        self.assertIn('Electricity production calculated as negative', str(e.exception))
+        params = GeophiresInputParameters(
+            {
+                'Reservoir Depth': 5,
+                'Gradient 1': 112,
+                'Power Plant Type': 2,
+                'Maximum Temperature': 600,
+            }
+        )
+
+        with self.assertLogs(level='WARNING') as cm:
+            result = client.get_geophires_result(params)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(
+            any('Electricity production calculated as negative. Clamping to zero.' in message for message in cm.output)
+        )
 
     def test_negative_electricity_production_direct_use_heat_clamped(self):
         client = GeophiresXClient()

--- a/tests/test_geophires_x.py
+++ b/tests/test_geophires_x.py
@@ -979,6 +979,22 @@ Print Output to Console, 1"""
             client.get_geophires_result(params)
         self.assertIn('Electricity production calculated as negative', str(e.exception))
 
+    def test_negative_electricity_production_direct_use_heat_clamped(self):
+        client = GeophiresXClient()
+        params = GeophiresInputParameters(
+            {
+                'Reservoir Depth': 5,
+                'Gradient 1': 112,
+                'Power Plant Type': 2,
+                'Maximum Temperature': 600,
+                'End-Use Option': EndUseOption.DIRECT_USE_HEAT.value,
+            }
+        )
+
+        result = client.get_geophires_result(params)
+
+        self.assertIsNotNone(result)
+
     def test_sbt_coaxial_raises_error(self):
         client = GeophiresXClient()
         with self.assertRaises(RuntimeError) as e:


### PR DESCRIPTION
## Summary
This PR changes negative electricity production handling to clamp to zero instead of failing, including after CHP parallel recalculation.

## Changes
- Add a shared electricity clamping path in `SurfacePlant`
- Apply clamping to the initial electricity calculation
- Apply clamping again after CHP parallel recalculation
- Update tests to validate clamping behavior and warning logging

## Notes
This PR was rebuilt from three fork-only commits onto current `upstream/main`.

## Validation
- Python compile checks passed for touched files
- `ruff` passed on the final branch state