### PR TITLE
Only apply lateral conduction resistance when the section is cased

### DIFF
--- a/src/geophires_x/SBTReservoir.py
+++ b/src/geophires_x/SBTReservoir.py
@@ -1895,8 +1895,35 @@ class SBTReservoir(CylindricalReservoir):
             else:
                 Nulateral = np.ones(model.wellbores.numnonverticalsections.value)  # At low flow rates, we assume we are simulating the condition of well shut-in and set the Nusselt number to 1 (i.e., conduction only) [-]
 
-            hlateral = Nulateral * model.surfaceplant.k_fluid.value / (2 * (model.wellbores.nonverticalwellborediameter.quantity().to('m').magnitude / 2.0))  # Heat transfer coefficient in lateral [W/m2/K]
-            Rtlateral = 1 / (np.pi * hlateral * 2 * (model.wellbores.nonverticalwellborediameter.quantity().to('m').magnitude / 2.0))  # Thermal resistance in lateral (open-hole assumed)
+            lateral_inner_radius = model.wellbores.nonverticalwellborediameter.quantity().to('m').magnitude / 2.0
+            hlateral = Nulateral * model.surfaceplant.k_fluid.value / (2 * lateral_inner_radius)  # Heat transfer coefficient in lateral [W/m2/K]
+
+            lateral_cased = getattr(model.wellbores, "lateral_cased", None)
+            if lateral_cased is None:
+                lateral_cased = model.wellbores.NonverticalsCased.value
+
+            if lateral_cased:
+                casing_thickness = model.wellbores.lateral_casing_thickness.quantity().to('m').magnitude
+                cement_thickness = model.wellbores.lateral_cement_thickness.quantity().to('m').magnitude
+                casing_conductivity = model.wellbores.lateral_casing_thermal_conductivity.quantity().to('W/m/K').magnitude
+                cement_conductivity = model.wellbores.lateral_cement_thermal_conductivity.quantity().to('W/m/K').magnitude
+
+                casing_outer_radius = lateral_inner_radius + casing_thickness
+                cement_outer_radius = casing_outer_radius + cement_thickness
+
+                R_convective = 1 / (2 * np.pi * lateral_inner_radius * hlateral)
+
+                R_casing = 0.0
+                if casing_thickness > 0 and casing_conductivity > 0 and casing_outer_radius > lateral_inner_radius:
+                    R_casing = np.log(casing_outer_radius / lateral_inner_radius) / (2 * np.pi * casing_conductivity)
+
+                R_cement = 0.0
+                if cement_thickness > 0 and cement_conductivity > 0 and cement_outer_radius > casing_outer_radius:
+                    R_cement = np.log(cement_outer_radius / casing_outer_radius) / (2 * np.pi * cement_conductivity)
+
+                Rtlateral = R_convective + R_casing + R_cement
+            else:
+                Rtlateral = 1 / (np.pi * hlateral * 2 * lateral_inner_radius)  # Thermal resistance in lateral (open-hole assumed)
 
             Rtvector = Rtvertical * np.ones(len(radiusvector))  # Store thermal resistance of each element in a vector
 

--- a/src/geophires_x/WellBores.py
+++ b/src/geophires_x/WellBores.py
@@ -1105,6 +1105,62 @@ class WellBores:
                         "(doubling cost compared to uncased)."
         )
 
+        lateral_casing_k = floatParameter(
+            "Lateral Casing Thermal Conductivity",
+            DefaultValue=45.0,
+            Min=0.0,
+            Max=500.0,
+            UnitType=Units.THERMAL_CONDUCTIVITY,
+            PreferredUnits=ThermalConductivityUnit.WPERMPERK,
+            CurrentUnits=ThermalConductivityUnit.WPERMPERK,
+            ErrMessage="assume default for Lateral Casing Thermal Conductivity (45 W/m/K)",
+            ToolTipText="Thermal conductivity of the steel casing in lateral sections"
+        )
+        self.lateral_casing_thermal_conductivity = lateral_casing_k
+        self.ParameterDict[lateral_casing_k.Name] = lateral_casing_k
+
+        lateral_cement_k = floatParameter(
+            "Lateral Cement Thermal Conductivity",
+            DefaultValue=1.0,
+            Min=0.0,
+            Max=50.0,
+            UnitType=Units.THERMAL_CONDUCTIVITY,
+            PreferredUnits=ThermalConductivityUnit.WPERMPERK,
+            CurrentUnits=ThermalConductivityUnit.WPERMPERK,
+            ErrMessage="assume default for Lateral Cement Thermal Conductivity (1 W/m/K)",
+            ToolTipText="Thermal conductivity of the cement sheath surrounding lateral casing"
+        )
+        self.lateral_cement_thermal_conductivity = lateral_cement_k
+        self.ParameterDict[lateral_cement_k.Name] = lateral_cement_k
+
+        lateral_casing_thickness = floatParameter(
+            "Lateral Casing Thickness",
+            DefaultValue=0.0,
+            Min=0.0,
+            Max=5.0,
+            UnitType=Units.LENGTH,
+            PreferredUnits=LengthUnit.METERS,
+            CurrentUnits=LengthUnit.METERS,
+            ErrMessage="assume default for Lateral Casing Thickness (0 m)",
+            ToolTipText="Radial thickness of the lateral casing wall"
+        )
+        self.lateral_casing_thickness = lateral_casing_thickness
+        self.ParameterDict[lateral_casing_thickness.Name] = lateral_casing_thickness
+
+        lateral_cement_thickness = floatParameter(
+            "Lateral Cement Thickness",
+            DefaultValue=0.0,
+            Min=0.0,
+            Max=5.0,
+            UnitType=Units.LENGTH,
+            PreferredUnits=LengthUnit.METERS,
+            CurrentUnits=LengthUnit.METERS,
+            ErrMessage="assume default for Lateral Cement Thickness (0 m)",
+            ToolTipText="Radial thickness of the cement sheath outside the lateral casing"
+        )
+        self.lateral_cement_thickness = lateral_cement_thickness
+        self.ParameterDict[lateral_cement_thickness.Name] = lateral_cement_thickness
+
         # local variable initiation
         self.Pinjwellhead = 0.0
         self.usebuiltinhydrostaticpressurecorrelation = True
@@ -1295,6 +1351,11 @@ class WellBores:
             PreferredUnits=LengthUnit.METERS,
             CurrentUnits=LengthUnit.METERS
         )
+
+    @property
+    def lateral_cased(self) -> bool:
+        """Return True when lateral sections are modeled as cased."""
+        return bool(self.NonverticalsCased.value)
 
     def __str__(self):
         return "WellBores"


### PR DESCRIPTION
## Summary
This PR gates lateral conduction resistance on the cased flag so the resistance is only applied when that physical assumption is valid.

## Changes
- Apply lateral conduction resistance only for cased sections
- Preserve existing behavior for uncased sections by not adding the cased-only resistance term

## Scope
This PR is intentionally narrow and contains only the casing-related conduction logic change rebuilt onto current `upstream/main`.