### PR TITLE
Preserve pressure-aware HIP-RA calculations and high-temperature utilization support

### DIFF
--- a/src/geophires_x/CylindricalReservoir.py
+++ b/src/geophires_x/CylindricalReservoir.py
@@ -254,8 +254,9 @@ class CylindricalReservoir(Reservoir):
         model.logger.info(f'complete {str(__class__)}: {sys._getframe().f_code.co_name}')
 
     def lithostatic_pressure(self) -> PlainQuantity:
-        """@override"""
-        Standard reservoir implementation uses depth but CylindricalReservoir sets depth to total drilled length
+        """@override
+
+        Standard reservoir implementation uses depth but CylindricalReservoir sets depth to total drilled length.
         """
         return quantity(static_pressure_MPa(self.rhorock.quantity().to('kg/m**3').magnitude,
                                             self.InputDepth.quantity().to('m').magnitude), 'MPa')

--- a/src/geophires_x/CylindricalReservoir.py
+++ b/src/geophires_x/CylindricalReservoir.py
@@ -255,6 +255,7 @@ class CylindricalReservoir(Reservoir):
 
     def lithostatic_pressure(self) -> PlainQuantity:
         """@override"""
-
+        Standard reservoir implementation uses depth but CylindricalReservoir sets depth to total drilled length
+        """
         return quantity(static_pressure_MPa(self.rhorock.quantity().to('kg/m**3').magnitude,
                                             self.InputDepth.quantity().to('m').magnitude), 'MPa')

--- a/src/geophires_x/GeoPHIRESUtils.py
+++ b/src/geophires_x/GeoPHIRESUtils.py
@@ -369,12 +369,13 @@ def RecoverableHeat(Twater_degC: float) -> float:
 
 
 @lru_cache
-def vapor_pressure_water_kPa(temperature_degC: float) -> float:
+def vapor_pressure_water_kPa(temperature_degC: float, pressure: Optional[PlainQuantity] = None) -> float:
     """
     Calculate the vapor pressure of water as a function of temperature.
 
     Args:
         temperature_degC: the temperature of water in degrees C
+        pressure: Pressure - should be provided as a Pint quantity that knows its units
     Returns:
         The vapor pressure of water as a function of temperature in kPa
     Raises:
@@ -388,8 +389,16 @@ def vapor_pressure_water_kPa(temperature_degC: float) -> float:
         raise ValueError(f'Input temperature ({temperature_degC}C) must be greater than or equal to 0')
 
     try:
-        return (quantity(CP.PropsSI('P', 'T', celsius_to_kelvin(temperature_degC), 'Q', 0, 'Water'), 'Pa')
-                .to('kPa').magnitude)
+        if pressure is not None:
+            return (quantity(
+                CP.PropsSI('P', 'T', celsius_to_kelvin(temperature_degC), 'P', pressure.to('Pa').magnitude, 'Water'),
+                'Pa',
+            )
+                    .to('kPa').magnitude)
+        else:
+            _logger.warning(f'vapor_pressure_water: No pressure provided, using vapor quality=0 instead')
+            return (quantity(CP.PropsSI('P', 'T', celsius_to_kelvin(temperature_degC), 'Q', 0, 'Water'), 'Pa')
+                    .to('kPa').magnitude)
 
     except (NotImplementedError, ValueError) as e:
         raise ValueError(f'Input temperature ({temperature_degC}C) is out of range or otherwise not implemented') from e

--- a/src/geophires_x/GeoPHIRESUtils.py
+++ b/src/geophires_x/GeoPHIRESUtils.py
@@ -85,7 +85,7 @@ _UtilEff = np.array(
         0.4,
         0.4,
         0.4,
-        0.5, # Extrapolate from fig 2 in https://geothermal-energy-journal.springeropen.com/articles/10.1186/s40517-019-0119-6
+        0.5,  # Extrapolate from fig 2 in https://geothermal-energy-journal.springeropen.com/articles/10.1186/s40517-019-0119-6
     ]
 )
 

--- a/src/hip_ra_x/hip_ra_x.py
+++ b/src/hip_ra_x/hip_ra_x.py
@@ -623,6 +623,9 @@ class HIP_RA_X:
                 if key in self.InputParameters:
                     ParameterReadIn = self.InputParameters[key]
 
+                    # Before we change the parameter, let's assume that the unit preferences will match -
+                    # if they don't, the later code will fix this.
+                    ParameterToModify.CurrentUnits = ParameterToModify.PreferredUnits
                     # this should handle all the non-special cases
                     ReadParameter(ParameterReadIn, ParameterToModify, self)
         else:


### PR DESCRIPTION
## Summary
This PR carries forward the remaining pressure-related HIP-RA changes that are not already present in current `upstream/main`.

## Changes
- Allow `vapor_pressure_water_kPa` to optionally use a supplied pressure
- Reset HIP-RA parameter current units to preferred units before parameter reads
- Clarify cylindrical reservoir lithostatic-pressure override documentation
- Preserve the higher-temperature utilization-efficiency table entry

## Notes
Most of the original fork-only HIP-RA pressure work is already reflected in current upstream, so this rebuilt PR is smaller than the original commit series.

## Validation
- `python -m compileall` passed for touched files
- Full `pytest` was not run in this environment because `pytest` is not installed locally
- Local `black` pre-commit is still broken in this environment due an unrelated Python 3.9 hook issue