### PR TITLE
Add cased and cemented AGS multi-lateral thermal resistance support

### DIFF
--- a/src/geophires_x/SBTReservoir.py
+++ b/src/geophires_x/SBTReservoir.py
@@ -1895,8 +1895,33 @@ class SBTReservoir(CylindricalReservoir):
             else:
                 Nulateral = np.ones(model.wellbores.numnonverticalsections.value)  # At low flow rates, we assume we are simulating the condition of well shut-in and set the Nusselt number to 1 (i.e., conduction only) [-]
 
-            hlateral = Nulateral * model.surfaceplant.k_fluid.value / (2 * (model.wellbores.nonverticalwellborediameter.quantity().to('m').magnitude / 2.0))  # Heat transfer coefficient in lateral [W/m2/K]
-            Rtlateral = 1 / (np.pi * hlateral * 2 * (model.wellbores.nonverticalwellborediameter.quantity().to('m').magnitude / 2.0))  # Thermal resistance in lateral (open-hole assumed)
+            lateral_inner_radius = model.wellbores.nonverticalwellborediameter.quantity().to('m').magnitude / 2.0
+            hlateral = Nulateral * model.surfaceplant.k_fluid.value / (2 * lateral_inner_radius)  # Heat transfer coefficient in lateral [W/m2/K]
+
+            # handle the cased vs. uncased lateral option
+            Rtlateral = 0.0
+            if model.wellbores.NonverticalsCased.value:
+                casing_thickness = model.wellbores.lateral_casing_thickness.quantity().to('m').magnitude
+                cement_thickness = model.wellbores.lateral_cement_thickness.quantity().to('m').magnitude
+                casing_conductivity = model.wellbores.lateral_casing_thermal_conductivity.quantity().to('W/m/K').magnitude
+                cement_conductivity = model.wellbores.lateral_cement_thermal_conductivity.quantity().to('W/m/K').magnitude
+
+                casing_outer_radius = lateral_inner_radius + casing_thickness
+                cement_outer_radius = casing_outer_radius + cement_thickness
+
+                R_convective = 1 / (2 * np.pi * lateral_inner_radius * hlateral)
+
+                R_casing = 0.0
+                if casing_thickness > 0 and casing_conductivity > 0 and casing_outer_radius > lateral_inner_radius:
+                    R_casing = np.log(casing_outer_radius / lateral_inner_radius) / (2 * np.pi * casing_conductivity)
+
+                R_cement = 0.0
+                if cement_thickness > 0 and cement_conductivity > 0 and cement_outer_radius > casing_outer_radius:
+                    R_cement = np.log(cement_outer_radius / casing_outer_radius) / (2 * np.pi * cement_conductivity)
+
+                Rtlateral = R_convective + R_casing + R_cement
+            else:
+                Rtlateral = 1 / (np.pi * hlateral * 2 * lateral_inner_radius)  # Thermal resistance in lateral (open-hole assumed)
 
             Rtvector = Rtvertical * np.ones(len(radiusvector))  # Store thermal resistance of each element in a vector
 

--- a/src/geophires_x_schema_generator/geophires-request.json
+++ b/src/geophires_x_schema_generator/geophires-request.json
@@ -1027,6 +1027,42 @@
       "minimum": null,
       "maximum": null
     },
+    "Lateral Casing Thermal Conductivity": {
+      "description": "Thermal conductivity of the steel casing in lateral sections",
+      "type": "number",
+      "units": "W/m/K",
+      "category": "Well Bores",
+      "default": 45.0,
+      "minimum": 0.0,
+      "maximum": 500.0
+    },
+    "Lateral Cement Thermal Conductivity": {
+      "description": "Thermal conductivity of the cement sheath surrounding lateral casing",
+      "type": "number",
+      "units": "W/m/K",
+      "category": "Well Bores",
+      "default": 1.0,
+      "minimum": 0.0,
+      "maximum": 50.0
+    },
+    "Lateral Casing Thickness": {
+      "description": "Radial thickness of the lateral casing wall",
+      "type": "number",
+      "units": "meter",
+      "category": "Well Bores",
+      "default": 0.0,
+      "minimum": 0.0,
+      "maximum": 5.0
+    },
+    "Lateral Cement Thickness": {
+      "description": "Radial thickness of the cement sheath outside the lateral casing",
+      "type": "number",
+      "units": "meter",
+      "category": "Well Bores",
+      "default": 0.0,
+      "minimum": 0.0,
+      "maximum": 5.0
+    },
     "Closed Loop Calculation Start Year": {
       "description": "Closed Loop Calculation Start Year",
       "type": "number",


### PR DESCRIPTION
## Summary
This PR adds support for modeling cased and cemented AGS multi-lateral sections in the SBT reservoir calculation.

## Changes
- Add cased-vs-open-hole lateral thermal resistance handling in `SBTReservoir`
- Include casing and cement conduction terms for lateral sections when laterals are marked as cased
- Add schema entries for lateral casing/cement thickness and thermal conductivity inputs

## Notes
This PR was rebuilt from a fork-only commit onto current `upstream/main` and trimmed to avoid overlap with other open PRs.

## Scope
This PR is intentionally limited to the AGS lateral thermal-resistance feature and the corresponding schema updates.