### PR TITLE
Fix scalar parsing for historical-array and pair-vector parameters

### DIFF
--- a/src/geophires_x/Parameter.py
+++ b/src/geophires_x/Parameter.py
@@ -2,14 +2,21 @@
 from __future__ import annotations
 
 import copy
+import csv
 import dataclasses
+import math
 import re
 
 import sys
 from collections.abc import Iterable
-from typing import List, Optional
 from dataclasses import dataclass, field
 from enum import IntEnum
+from pathlib import Path
+from typing import List, Optional
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+import numpy as np
 from forex_python.converter import CurrencyRates, CurrencyCodes
 
 from abc import ABC
@@ -334,7 +341,13 @@ def ReadParameter(ParameterReadIn: ParameterEntry, ParamToModify, model) -> None
         return
 
     # deal with the case where the value has a unit involved - that will be indicated by a space in it
-    if ' ' in ParameterReadIn.sValue and SCHEDULE_DSL_MULTIPLIER_SYMBOL not in ParameterReadIn.sValue:
+    if (
+        ' ' in ParameterReadIn.sValue
+        and SCHEDULE_DSL_MULTIPLIER_SYMBOL not in ParameterReadIn.sValue
+        and not isinstance(ParamToModify, listParameter)
+        and not _is_pair_vector_candidate(ParameterReadIn, ParamToModify)
+        and not _is_historical_array_candidate(ParameterReadIn, ParamToModify)
+    ):
         new_str = ConvertUnits(ParamToModify, ParameterReadIn.sValue, model)
         if len(new_str) > 0:
             ParameterReadIn.sValue = new_str
@@ -512,6 +525,289 @@ def _read_list_parameter(ParameterReadIn: ParameterEntry, ParamToModify: listPar
 
     if not ParamToModify.Valid and ParamToModify.auto_raise_exception_on_invalid_read:
         raise ValueError(f'Invalid value provided for {ParamToModify.Name}: {ParamToModify.value}')
+
+_PAIR_VECTOR_MAX_BYTES = 1_000_000
+
+
+def _parse_csv_pair_line(line: str, param_to_modify=None, model=None) -> Optional[np.ndarray]:
+    row = next(csv.reader([line]), None)
+    if row is None or len(row) != 2:
+        return None
+
+    converted_row: list[str] = []
+    for raw_component in row:
+        component = raw_component.strip()
+        if param_to_modify is not None and model is not None and ' ' in component:
+            try:
+                component = ConvertUnits(param_to_modify, component, model)
+            except Exception:
+                # Fall back to scalar parsing behavior if conversion fails.
+                return None
+        converted_row.append(component)
+
+    try:
+        x = float(converted_row[0])
+        y = float(converted_row[1])
+    except ValueError:
+        return None
+
+    if not math.isfinite(x) or not math.isfinite(y):
+        return None
+
+    return np.array([x, y], dtype=float)
+
+
+def _try_parse_pair_vector_inline(raw_value: str, param_to_modify=None, model=None) -> Optional[np.ndarray]:
+    candidate = raw_value.strip()
+    if candidate == '':
+        return None
+
+    if candidate.startswith('[') and candidate.endswith(']'):
+        candidate = candidate[1:-1].strip()
+
+    return _parse_csv_pair_line(candidate, param_to_modify=param_to_modify, model=model)
+
+
+def _pair_vector_from_csv_text(csv_text: str, param_to_modify=None, model=None) -> Optional[np.ndarray]:
+    for line in csv_text.splitlines():
+        stripped = line.strip()
+        if stripped == '' or stripped.startswith('#') or stripped.startswith('--') or stripped.startswith('*'):
+            continue
+        return _parse_csv_pair_line(stripped, param_to_modify=param_to_modify, model=model)
+
+    return None
+
+
+def _try_parse_pair_vector_csv_file(path_str: str, param_to_modify=None, model=None) -> Optional[np.ndarray]:
+    path = Path(path_str)
+    if not path.is_file():
+        return None
+
+    if path.stat().st_size > _PAIR_VECTOR_MAX_BYTES:
+        return None
+
+    with path.open(encoding='UTF-8') as f:
+        text = f.read(_PAIR_VECTOR_MAX_BYTES + 1)
+        if len(text) > _PAIR_VECTOR_MAX_BYTES:
+            return None
+
+    return _pair_vector_from_csv_text(text, param_to_modify=param_to_modify, model=model)
+
+
+def _try_parse_pair_vector_csv_url(url_str: str, param_to_modify=None, model=None) -> Optional[np.ndarray]:
+    parsed = urlparse(url_str)
+    if parsed.scheme not in ['http', 'https']:
+        return None
+
+    with urlopen(url_str, timeout=5) as response:
+        data = response.read(_PAIR_VECTOR_MAX_BYTES + 1)
+
+    if len(data) > _PAIR_VECTOR_MAX_BYTES:
+        return None
+
+    try:
+        text = data.decode('utf-8')
+    except UnicodeDecodeError:
+        return None
+
+    return _pair_vector_from_csv_text(text, param_to_modify=param_to_modify, model=model)
+
+
+def _parse_numeric_list_tokens(tokens: list[str], param_to_modify, model) -> Optional[list[float]]:
+    values: list[float] = []
+
+    for raw_token in tokens:
+        token = raw_token.strip()
+        if token == '':
+            continue
+
+        if token.startswith('['):
+            token = token[1:]
+        if token.endswith(']'):
+            token = token[:-1]
+        token = token.strip()
+        if token == '':
+            continue
+
+        if ' ' in token:
+            try:
+                token = ConvertUnits(param_to_modify, token, model)
+            except Exception:
+                return None
+
+        try:
+            value = float(token)
+        except ValueError:
+            return None
+
+        if not math.isfinite(value):
+            return None
+
+        values.append(value)
+
+    return values
+
+
+def _parse_numeric_list_text(csv_text: str, param_to_modify, model) -> Optional[list[float]]:
+    values: list[float] = []
+
+    for raw_line in csv_text.splitlines():
+        line = raw_line.strip()
+        if line == '' or line.startswith('#') or line.startswith('--') or line.startswith('*'):
+            continue
+
+        row = next(csv.reader([line]), None)
+        if row is None:
+            continue
+
+        parsed_row = _parse_numeric_list_tokens(row, param_to_modify, model)
+        if parsed_row is None:
+            return None
+
+        values.extend(parsed_row)
+
+    return values if len(values) > 0 else None
+
+
+def _try_read_numeric_list_from_source(parameter_read_in: ParameterEntry, param_to_modify, model) -> Optional[list[float]]:
+    candidates: list[str] = []
+
+    rhs = _raw_input_rhs(parameter_read_in.raw_entry)
+    if rhs is not None:
+        candidates.append(rhs)
+
+    if parameter_read_in.sValue is not None:
+        candidates.append(parameter_read_in.sValue.strip())
+
+    for candidate in candidates:
+        if candidate == '':
+            continue
+
+        parsed_url = urlparse(candidate)
+        if parsed_url.scheme in ['http', 'https']:
+            try:
+                with urlopen(candidate, timeout=5) as response:
+                    data = response.read(_PAIR_VECTOR_MAX_BYTES + 1)
+                if len(data) > _PAIR_VECTOR_MAX_BYTES:
+                    continue
+                text = data.decode('utf-8')
+            except Exception:
+                continue
+
+            parsed_values = _parse_numeric_list_text(text, param_to_modify, model)
+            if parsed_values is not None:
+                return parsed_values
+            continue
+
+        file_path = Path(candidate)
+        if file_path.is_file():
+            if file_path.stat().st_size > _PAIR_VECTOR_MAX_BYTES:
+                continue
+
+            try:
+                with file_path.open(encoding='UTF-8') as f:
+                    text = f.read(_PAIR_VECTOR_MAX_BYTES + 1)
+                if len(text) > _PAIR_VECTOR_MAX_BYTES:
+                    continue
+            except Exception:
+                continue
+
+            parsed_values = _parse_numeric_list_text(text, param_to_modify, model)
+            if parsed_values is not None:
+                return parsed_values
+
+    return None
+
+
+def _raw_input_rhs(raw_entry: Optional[str]) -> Optional[str]:
+    if raw_entry is None or ',' not in raw_entry:
+        return None
+
+    # keep behavior aligned with list-parameter parsing: text after '--' is comment
+    entry = raw_entry.split('--')[0]
+    if ',' not in entry:
+        return None
+
+    # Drop incidental trailing delimiters (e.g. "Parameter, 8 degC, -- comment") so scalar
+    # values with comments are not misclassified as CSV-like pair/historical arrays.
+    return entry.split(',', 1)[1].strip().rstrip(',').strip()
+
+
+def _is_pair_vector_candidate(parameter_read_in: ParameterEntry, param_to_modify=None) -> bool:
+    if param_to_modify is None or not getattr(param_to_modify, 'AllowPairVectorInput', False):
+        return False
+
+    candidates = []
+    rhs = _raw_input_rhs(parameter_read_in.raw_entry)
+    if rhs is not None:
+        candidates.append(rhs)
+    if parameter_read_in.sValue is not None:
+        candidates.append(parameter_read_in.sValue.strip())
+
+    for candidate in candidates:
+        lowered = candidate.lower()
+        if ',' in candidate or candidate.startswith('[') or lowered.endswith('.csv'):
+            return True
+        parsed = urlparse(candidate)
+        if parsed.scheme in ['http', 'https']:
+            return True
+
+    return False
+
+
+def _is_historical_array_candidate(parameter_read_in: ParameterEntry, param_to_modify=None) -> bool:
+    if param_to_modify is None or not getattr(param_to_modify, 'AllowHistoricalArrayInput', False):
+        return False
+
+    candidates = []
+    rhs = _raw_input_rhs(parameter_read_in.raw_entry)
+    if rhs is not None:
+        candidates.append(rhs)
+    if parameter_read_in.sValue is not None:
+        candidates.append(parameter_read_in.sValue.strip())
+
+    for candidate in candidates:
+        lowered = candidate.lower()
+        if ',' in candidate or '\n' in candidate or lowered.endswith('.csv'):
+            return True
+        parsed = urlparse(candidate)
+        if parsed.scheme in ['http', 'https']:
+            return True
+
+    return False
+
+
+def _try_read_pair_vector(parameter_read_in: ParameterEntry, param_to_modify=None, model=None) -> Optional[np.ndarray]:
+    candidates = []
+
+    rhs = _raw_input_rhs(parameter_read_in.raw_entry)
+    if rhs is not None:
+        candidates.append(rhs)
+
+    if parameter_read_in.sValue is not None:
+        candidates.append(parameter_read_in.sValue.strip())
+
+    for candidate in candidates:
+        if candidate == '':
+            continue
+
+        parsed = _try_parse_pair_vector_inline(candidate, param_to_modify=param_to_modify, model=model)
+        if parsed is not None:
+            return parsed
+
+        parsed = _try_parse_pair_vector_csv_file(candidate, param_to_modify=param_to_modify, model=model)
+        if parsed is not None:
+            return parsed
+
+        try:
+            parsed = _try_parse_pair_vector_csv_url(candidate, param_to_modify=param_to_modify, model=model)
+            if parsed is not None:
+                return parsed
+        except Exception:
+            # Fall back to scalar parsing if URL retrieval/parsing fails.
+            continue
+
+    return None
 
 
 def ConvertUnits(ParamToModify, strUnit: str, model) -> str:

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -2,6 +2,10 @@ import os
 import sys
 import unittest
 from pathlib import Path
+from tempfile import NamedTemporaryFile
+from unittest.mock import patch
+
+import numpy as np
 
 from geophires_x.Model import Model
 from geophires_x.Parameter import ConvertUnitsBack
@@ -26,6 +30,184 @@ from tests.base_test_case import BaseTestCase
 
 
 class ParameterTestCase(BaseTestCase):
+
+    def test_read_parameter_allows_pair_vector_inline_for_float_parameter(self):
+        model = self._new_model()
+        param = floatParameter(Name='Reservoir Temperature', DefaultValue=150.0, Min=0.0, Max=500.0)
+        param.AllowPairVectorInput = True
+
+        ReadParameter(
+            ParameterEntry(
+                Name='Reservoir Temperature',
+                sValue='[1000',
+                raw_entry='Reservoir Temperature, [1000, 200]',
+            ),
+            param,
+            model,
+        )
+
+        self.assertIsInstance(param.value, np.ndarray)
+        self.assertTrue(np.array_equal(param.value, np.array([1000.0, 200.0])))
+        self.assertTrue(param.Provided)
+        self.assertTrue(param.Valid)
+
+    def test_read_parameter_allows_pair_vector_csv_file_for_float_parameter(self):
+        model = self._new_model()
+        param = floatParameter(Name='Reservoir Temperature', DefaultValue=150.0, Min=0.0, Max=500.0)
+        param.AllowPairVectorInput = True
+
+        with NamedTemporaryFile(mode='w+', suffix='.csv', delete=False) as f:
+            f.write('1000,200\n')
+            csv_file = f.name
+
+        try:
+            ReadParameter(
+                ParameterEntry(
+                    Name='Reservoir Temperature',
+                    sValue=csv_file,
+                    raw_entry=f'Reservoir Temperature, {csv_file}',
+                ),
+                param,
+                model,
+            )
+        finally:
+            Path(csv_file).unlink()
+
+        self.assertIsInstance(param.value, np.ndarray)
+        self.assertTrue(np.array_equal(param.value, np.array([1000.0, 200.0])))
+
+    def test_read_parameter_allows_pair_vector_csv_url_for_float_parameter(self):
+        model = self._new_model()
+        param = floatParameter(Name='Reservoir Temperature', DefaultValue=150.0, Min=0.0, Max=500.0)
+        param.AllowPairVectorInput = True
+
+        class _MockResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self, n=-1):
+                return b'1000,200\n'
+
+        with patch('geophires_x.Parameter.urlopen', return_value=_MockResponse()):
+            ReadParameter(
+                ParameterEntry(
+                    Name='Reservoir Temperature',
+                    sValue='https://example.com/pair.csv',
+                    raw_entry='Reservoir Temperature, https://example.com/pair.csv',
+                ),
+                param,
+                model,
+            )
+
+        self.assertIsInstance(param.value, np.ndarray)
+        self.assertTrue(np.array_equal(param.value, np.array([1000.0, 200.0])))
+
+    def test_read_parameter_pair_vector_applies_convert_units_in_loop(self):
+        model = self._new_model()
+        param = floatParameter(
+            Name='Reservoir Temperature',
+            DefaultValue=150.0,
+            Min=0.0,
+            Max=500.0,
+            UnitType=Units.TEMPERATURE,
+            PreferredUnits=TemperatureUnit.CELSIUS,
+            CurrentUnits=TemperatureUnit.CELSIUS,
+        )
+        param.AllowPairVectorInput = True
+
+        ReadParameter(
+            ParameterEntry(
+                Name='Reservoir Temperature',
+                sValue='[10, 212 degF]',
+            ),
+            param,
+            model,
+        )
+
+        self.assertIsInstance(param.value, np.ndarray)
+        self.assertAlmostEqual(param.value[0], 10.0, places=6)
+        self.assertAlmostEqual(param.value[1], 100.0, places=6)
+
+    def test_historical_array_candidate_ignores_trailing_value_comma_before_comment(self):
+        param = floatParameter(Name='Ambient Temperature', DefaultValue=10.0, Min=-50.0, Max=100.0)
+        param.AllowHistoricalArrayInput = True
+
+        parameter_entry = ParameterEntry(
+            Name='Ambient Temperature',
+            sValue='8 degC',
+            raw_entry='Ambient Temperature, 8 degC, -- per the paper',
+        )
+
+        self.assertFalse(_is_historical_array_candidate(parameter_entry, param))
+
+    def test_read_list_parameter_allows_csv_file_input_with_units(self):
+        model = self._new_model()
+        param = listParameter(
+            Name='Thicknesses',
+            DefaultValue=[1000.0],
+            Min=0.0,
+            Max=100000.0,
+            UnitType=Units.LENGTH,
+            PreferredUnits=LengthUnit.METERS,
+            CurrentUnits=LengthUnit.METERS,
+        )
+
+        with NamedTemporaryFile(mode='w+', suffix='.csv', delete=False) as f:
+            f.write('1 km\n2 km\n3 km\n')
+            csv_file = f.name
+
+        try:
+            ReadParameter(
+                ParameterEntry(
+                    Name='Thicknesses',
+                    sValue=csv_file,
+                    raw_entry=f'Thicknesses, {csv_file}',
+                ),
+                param,
+                model,
+            )
+        finally:
+            Path(csv_file).unlink()
+
+        self.assertEqual([1000.0, 2000.0, 3000.0], param.value)
+
+    def test_read_list_parameter_allows_csv_url_input_with_units(self):
+        model = self._new_model()
+        param = listParameter(
+            Name='Thicknesses',
+            DefaultValue=[1000.0],
+            Min=0.0,
+            Max=100000.0,
+            UnitType=Units.LENGTH,
+            PreferredUnits=LengthUnit.METERS,
+            CurrentUnits=LengthUnit.METERS,
+        )
+
+        class _MockResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self, n=-1):
+                return b'1 km\n2 km\n'
+
+        with patch('geophires_x.Parameter.urlopen', return_value=_MockResponse()):
+            ReadParameter(
+                ParameterEntry(
+                    Name='Thicknesses',
+                    sValue='https://example.com/thicknesses.csv',
+                    raw_entry='Thicknesses, https://example.com/thicknesses.csv',
+                ),
+                param,
+                model,
+            )
+
+        self.assertEqual([1000.0, 2000.0], param.value)
     def test_convert_units_back(self):
         model = self._new_model()  # TODO mock instead
 
@@ -231,18 +413,6 @@ class ParameterTestCase(BaseTestCase):
         ]
         self.assertEqual('kilogram', total_avoided_carbon_emissions_vu['unit'])
         self.assertEqual(int(total_avoided_carbon_emissions_vu['value']), total_capacity_payment_revenue_usd)
-
-    def test_historical_array_candidate_ignores_trailing_value_comma_before_comment(self):
-        param = floatParameter(Name='Ambient Temperature', DefaultValue=10.0, Min=-50.0, Max=100.0)
-        param.AllowHistoricalArrayInput = True
-
-        parameter_entry = ParameterEntry(
-            Name='Ambient Temperature',
-            sValue='8 degC',
-            raw_entry='Ambient Temperature, 8 degC, -- per the paper',
-        )
-
-        self.assertFalse(_is_historical_array_candidate(parameter_entry, param))
 
     def test_read_parameter_historical_array_allows_scalar_with_units(self):
         model = self._new_model()

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -7,6 +7,9 @@ from geophires_x.Model import Model
 from geophires_x.Parameter import ConvertUnitsBack
 from geophires_x.Parameter import OutputParameter
 from geophires_x.Parameter import Parameter
+from geophires_x.Parameter import ParameterEntry
+from geophires_x.Parameter import ReadParameter
+from geophires_x.Parameter import _is_historical_array_candidate
 from geophires_x.Parameter import floatParameter
 from geophires_x.Parameter import listParameter
 from geophires_x.Units import CostPerMassUnit
@@ -14,6 +17,7 @@ from geophires_x.Units import CurrencyUnit
 from geophires_x.Units import EnergyCostUnit
 from geophires_x.Units import LengthUnit
 from geophires_x.Units import PressureUnit
+from geophires_x.Units import TemperatureUnit
 from geophires_x.Units import Units
 from geophires_x_client import GeophiresXClient
 from geophires_x_client import GeophiresXResult
@@ -227,6 +231,47 @@ class ParameterTestCase(BaseTestCase):
         ]
         self.assertEqual('kilogram', total_avoided_carbon_emissions_vu['unit'])
         self.assertEqual(int(total_avoided_carbon_emissions_vu['value']), total_capacity_payment_revenue_usd)
+
+    def test_historical_array_candidate_ignores_trailing_value_comma_before_comment(self):
+        param = floatParameter(Name='Ambient Temperature', DefaultValue=10.0, Min=-50.0, Max=100.0)
+        param.AllowHistoricalArrayInput = True
+
+        parameter_entry = ParameterEntry(
+            Name='Ambient Temperature',
+            sValue='8 degC',
+            raw_entry='Ambient Temperature, 8 degC, -- per the paper',
+        )
+
+        self.assertFalse(_is_historical_array_candidate(parameter_entry, param))
+
+    def test_read_parameter_historical_array_allows_scalar_with_units(self):
+        model = self._new_model()
+        param = floatParameter(
+            Name='Ambient Temperature',
+            DefaultValue=15.0,
+            Min=-50.0,
+            Max=50.0,
+            UnitType=Units.TEMPERATURE,
+            PreferredUnits=TemperatureUnit.CELSIUS,
+            CurrentUnits=TemperatureUnit.CELSIUS,
+        )
+        param.AllowHistoricalArrayInput = True
+        param.HistoricalXDimension = 'time'
+        param.HistoricalYDimension = 'temperature'
+        param.HistoricalDefaultXUnits = 'hour'
+        param.HistoricalDefaultYUnits = 'celsius'
+        param.HistoricalResampleToHourlyYear = True
+
+        entry = ParameterEntry(
+            Name='Ambient Temperature',
+            sValue='10 degC',
+            raw_entry='Ambient Temperature, 10 degC',
+        )
+        ReadParameter(entry, param, model)
+
+        self.assertTrue(param.Provided)
+        self.assertTrue(param.Valid)
+        self.assertAlmostEqual(10.0, param.value, places=6)
 
     # noinspection PyMethodMayBeStatic
     def _new_model(self) -> Model:


### PR DESCRIPTION
## Summary
This PR fixes scalar parameter parsing in cases where parameters can also accept historical-array or pair-vector inputs.

It preserves normal scalar-with-units behavior while avoiding misclassification as CSV-like structured input.

## Changes
- Avoid treating scalar values with units as structured historical-array or pair-vector input
- Ignore incidental trailing delimiters in raw parameter values before candidate detection
- Add parser helpers for pair-vector and structured list input sources
- Add tests covering:
  - inline pair-vector parsing
  - CSV file/URL pair-vector parsing
  - unit conversion inside pair-vector parsing
  - list CSV file/URL parsing with units
  - trailing-comma historical-array candidate detection
  - scalar-with-units handling for historical-array-enabled parameters

## Notes
This PR was rebuilt from two fork-only commits onto current `upstream/main`. The resulting diff is larger than the original bugfix summary because the helper parsing infrastructure those fixes relied on is not present in current upstream.

## Validation
- `python -m compileall src/geophires_x/Parameter.py tests/test_parameter.py` passed
- Full Python test execution was not completed in this environment because required runtime dependencies are missing
- Local `black` pre-commit is broken in this environment due an unrelated Python 3.9 hook issue